### PR TITLE
(RFR) feat: aside filtered for client or visitors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: yarn start

--- a/notes.md
+++ b/notes.md
@@ -191,3 +191,5 @@ To solve this we have to set basePath property manually
 
 - Body margin has to be set to 0. Not found in the documentation...
 - ShowBase : if you don't use ShowView you'll have to take care of loading record lifecycle. ie: check if record exists
+
+- FilterLiveSearch doc doesn't mention the default behaviour of setting source='q' so by default a simple : <FilterLiveSearch/> would be enough.

--- a/src/customers/CustomerBulkActionButtons.js
+++ b/src/customers/CustomerBulkActionButtons.js
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { Fragment } from "react";
+import { BulkDeleteButton, BulkExportButton } from "react-admin";
+
+export const CustomerBulkActionButtons = (props) => (
+    <Fragment>
+        <BulkExportButton />
+        {/* default bulk delete action */}
+        <BulkDeleteButton {...props} />
+    </Fragment>
+);

--- a/src/customers/CustomerHasNewsletterFilter.js
+++ b/src/customers/CustomerHasNewsletterFilter.js
@@ -1,0 +1,9 @@
+import MailIcon from "@material-ui/icons/MailOutline";
+import { FilterList, FilterListItem } from "react-admin";
+
+export const HasNewsletterFilter = () => (
+    <FilterList label="Has newsletter" icon={<MailIcon />}>
+        <FilterListItem label="True" value={{ has_newsletter: true }} />
+        <FilterListItem label="False" value={{ has_newsletter: false }} />
+    </FilterList>
+);

--- a/src/customers/CustomerHasOreredFilter.js
+++ b/src/customers/CustomerHasOreredFilter.js
@@ -1,0 +1,20 @@
+import MonetizationOnIcon from "@material-ui/icons/MonetizationOnOutlined";
+import { FilterList, FilterListItem } from "react-admin";
+export const HasOrderedFilter = () => (
+    <FilterList label="Has ordered" icon={<MonetizationOnIcon />}>
+        <FilterListItem
+            label="True"
+            value={{
+                nb_commands_gte: 1,
+                nb_commands_lte: undefined,
+            }}
+        />
+        <FilterListItem
+            label="False"
+            value={{
+                nb_commands_gte: undefined,
+                nb_commands_lte: 0,
+            }}
+        />
+    </FilterList>
+);

--- a/src/customers/CustomerLastVisitFilter.js
+++ b/src/customers/CustomerLastVisitFilter.js
@@ -1,0 +1,65 @@
+import AccessTimeIcon from "@material-ui/icons/AccessTime";
+import {
+    endOfYesterday,
+    startOfMonth,
+    startOfWeek,
+    subMonths,
+    subWeeks,
+} from "date-fns";
+import { FilterList, FilterListItem } from "react-admin";
+
+export const LastVisitedFilter = () => (
+    <FilterList label="Last visited" icon={<AccessTimeIcon />}>
+        <FilterListItem
+            label="Today"
+            value={{
+                last_seen_gte: endOfYesterday().toISOString(),
+                last_seen_lte: undefined,
+            }}
+        />
+        <FilterListItem
+            label="This week"
+            value={{
+                last_seen_gte: startOfWeek(new Date()).toISOString(),
+                last_seen_lte: undefined,
+            }}
+        />
+        <FilterListItem
+            label="Last week"
+            value={{
+                last_seen_gte: subWeeks(
+                    startOfWeek(new Date()),
+                    1
+                ).toISOString(),
+                last_seen_lte: startOfWeek(new Date()).toISOString(),
+            }}
+        />
+        <FilterListItem
+            label="This month"
+            value={{
+                last_seen_gte: startOfMonth(new Date()).toISOString(),
+                last_seen_lte: undefined,
+            }}
+        />
+        <FilterListItem
+            label="Last month"
+            value={{
+                last_seen_gte: subMonths(
+                    startOfMonth(new Date()),
+                    1
+                ).toISOString(),
+                last_seen_lte: startOfMonth(new Date()).toISOString(),
+            }}
+        />
+        <FilterListItem
+            label="Earlier"
+            value={{
+                last_seen_gte: undefined,
+                last_seen_lte: subMonths(
+                    startOfMonth(new Date()),
+                    1
+                ).toISOString(),
+            }}
+        />
+    </FilterList>
+);

--- a/src/customers/CustomersFilter.js
+++ b/src/customers/CustomersFilter.js
@@ -1,7 +1,0 @@
-import { Filter, SearchInput } from "react-admin";
-
-export const CustomersFilter = (props) => (
-    <Filter {...props}>
-        <SearchInput source="q" alwaysOn />
-    </Filter>
-);

--- a/src/customers/CustomersFiltersSidebar.js
+++ b/src/customers/CustomersFiltersSidebar.js
@@ -1,0 +1,31 @@
+import { Card, CardContent } from "@material-ui/core";
+import MonetizationOnIcon from "@material-ui/icons/MonetizationOnOutlined";
+import * as React from "react";
+import { FilterList, FilterListItem } from "react-admin";
+
+const HasOrderedFilter = () => (
+    <FilterList label="Has ordered" icon={<MonetizationOnIcon />}>
+        <FilterListItem
+            label="True"
+            value={{
+                nb_commands_gte: 1,
+                nb_commands_lte: undefined,
+            }}
+        />
+        <FilterListItem
+            label="False"
+            value={{
+                nb_commands_gte: undefined,
+                nb_commands_lte: 0,
+            }}
+        />
+    </FilterList>
+);
+
+export const CustomersFilterSidebar = () => (
+    <Card style={{ order: -1 }}>
+        <CardContent>
+            <HasOrderedFilter />
+        </CardContent>
+    </Card>
+);

--- a/src/customers/CustomersFiltersSidebar.js
+++ b/src/customers/CustomersFiltersSidebar.js
@@ -1,14 +1,14 @@
 import { Card, CardContent } from "@material-ui/core";
 import * as React from "react";
+import { FilterLiveSearch } from "react-admin";
 import { HasNewsletterFilter } from "./CustomerHasNewsletterFilter";
 import { HasOrderedFilter } from "./CustomerHasOreredFilter";
 import { LastVisitedFilter } from "./CustomerLastVisitFilter";
-import { CustomersFilter } from "./CustomersFilter";
 
 export const CustomersFilterSidebar = () => (
     <Card style={{ order: -1 }}>
         <CardContent>
-            <CustomersFilter />
+            <FilterLiveSearch />
             <LastVisitedFilter />
             <HasOrderedFilter />
             <HasNewsletterFilter />

--- a/src/customers/CustomersFiltersSidebar.js
+++ b/src/customers/CustomersFiltersSidebar.js
@@ -1,31 +1,15 @@
 import { Card, CardContent } from "@material-ui/core";
-import MonetizationOnIcon from "@material-ui/icons/MonetizationOnOutlined";
 import * as React from "react";
-import { FilterList, FilterListItem } from "react-admin";
-
-const HasOrderedFilter = () => (
-    <FilterList label="Has ordered" icon={<MonetizationOnIcon />}>
-        <FilterListItem
-            label="True"
-            value={{
-                nb_commands_gte: 1,
-                nb_commands_lte: undefined,
-            }}
-        />
-        <FilterListItem
-            label="False"
-            value={{
-                nb_commands_gte: undefined,
-                nb_commands_lte: 0,
-            }}
-        />
-    </FilterList>
-);
+import { HasNewsletterFilter } from "./CustomerHasNewsletterFilter";
+import { HasOrderedFilter } from "./CustomerHasOreredFilter";
+import { LastVisitedFilter } from "./CustomerLastVisitFilter";
 
 export const CustomersFilterSidebar = () => (
     <Card style={{ order: -1 }}>
         <CardContent>
+            <LastVisitedFilter />
             <HasOrderedFilter />
+            <HasNewsletterFilter />
         </CardContent>
     </Card>
 );

--- a/src/customers/CustomersFiltersSidebar.js
+++ b/src/customers/CustomersFiltersSidebar.js
@@ -3,10 +3,12 @@ import * as React from "react";
 import { HasNewsletterFilter } from "./CustomerHasNewsletterFilter";
 import { HasOrderedFilter } from "./CustomerHasOreredFilter";
 import { LastVisitedFilter } from "./CustomerLastVisitFilter";
+import { CustomersFilter } from "./CustomersFilter";
 
 export const CustomersFilterSidebar = () => (
     <Card style={{ order: -1 }}>
         <CardContent>
+            <CustomersFilter />
             <LastVisitedFilter />
             <HasOrderedFilter />
             <HasNewsletterFilter />

--- a/src/customers/CustomersList.js
+++ b/src/customers/CustomersList.js
@@ -8,8 +8,13 @@ import {
     TextField,
 } from "react-admin";
 import { CustomersFilter } from "./CustomersFilter";
+import { CustomersFilterSidebar } from "./CustomersFiltersSidebar";
 export const CustomersList = (props) => (
-    <List filters={<CustomersFilter />} {...props}>
+    <List
+        filters={<CustomersFilter />}
+        aside={<CustomersFilterSidebar />}
+        {...props}
+    >
         <Datagrid rowClick="show">
             <FunctionField
                 label="name"

--- a/src/customers/CustomersList.js
+++ b/src/customers/CustomersList.js
@@ -5,7 +5,6 @@ import {
     FunctionField,
     List,
     NumberField,
-    TextField,
 } from "react-admin";
 import { CustomersFilter } from "./CustomersFilter";
 import { CustomersFilterSidebar } from "./CustomersFiltersSidebar";
@@ -31,7 +30,7 @@ export const CustomersList = (props) => (
                 source="total_spent"
                 options={{ style: "currency", currency: "USD" }}
             />
-            <TextField source="latest_purchase" />
+            <DateField source="latest_purchase" />
             <BooleanField source="has_newsletter" />
         </Datagrid>
     </List>

--- a/src/customers/CustomersList.js
+++ b/src/customers/CustomersList.js
@@ -6,14 +6,9 @@ import {
     List,
     NumberField,
 } from "react-admin";
-import { CustomersFilter } from "./CustomersFilter";
 import { CustomersFilterSidebar } from "./CustomersFiltersSidebar";
 export const CustomersList = (props) => (
-    <List
-        filters={<CustomersFilter />}
-        aside={<CustomersFilterSidebar />}
-        {...props}
-    >
+    <List aside={<CustomersFilterSidebar />} {...props}>
         <Datagrid rowClick="show">
             <FunctionField
                 label="name"

--- a/src/customers/CustomersList.js
+++ b/src/customers/CustomersList.js
@@ -6,9 +6,14 @@ import {
     List,
     NumberField,
 } from "react-admin";
+import { CustomerBulkActionButtons } from "./CustomerBulkActionButtons";
 import { CustomersFilterSidebar } from "./CustomersFiltersSidebar";
 export const CustomersList = (props) => (
-    <List aside={<CustomersFilterSidebar />} {...props}>
+    <List
+        aside={<CustomersFilterSidebar />}
+        bulkActionButtons={<CustomerBulkActionButtons />}
+        {...props}
+    >
         <Datagrid rowClick="show">
             <FunctionField
                 label="name"

--- a/src/customers/index.js
+++ b/src/customers/index.js
@@ -1,7 +1,8 @@
 import { CustomersList } from "./CustomersList";
 import { CustomersShow } from "./CustomersShow";
 
-export default {
+const customers = {
     list: CustomersList,
     show: CustomersShow,
 };
+export default customers;

--- a/src/orders/index.js
+++ b/src/orders/index.js
@@ -1,7 +1,7 @@
 import { OrdersList } from "./OrdersList";
 import { OrdersShow } from "./OrdersShow";
-
-export default {
+const orders = {
     list: OrdersList,
     show: OrdersShow,
 };
+export default orders;

--- a/src/reviews/index.js
+++ b/src/reviews/index.js
@@ -1,7 +1,8 @@
 import { ReviewsList } from "./ReviewsList";
 import { ReviewsShow } from "./ReviewsShow";
 
-export default {
+const reviews = {
     list: ReviewsList,
     show: ReviewsShow,
 };
+export default reviews;


### PR DESCRIPTION
## Description

Add filter aside to filter customers that has ordered at least one poster.
![Peek 04-03-2021 15-42](https://user-images.githubusercontent.com/560852/109980496-453c8c00-7d00-11eb-9a5a-ff75feceea70.gif)


## Related Issue

[trello](https://trello.com/c/65ayUWMA/5-as-sandra-i-want-to-send-an-email-to-a-subset-of-customers)

## ToDo list:

- [x] Create preset filterList and filterList item.
- [x] Add this filter list as `aside` prop
